### PR TITLE
Dismiss activity popover with action button.

### DIFF
--- a/PBWebViewController/PBWebViewController.m
+++ b/PBWebViewController/PBWebViewController.m
@@ -159,6 +159,11 @@
 
 - (void)action:(id)sender
 {
+    if (self.activitiyPopoverController.popoverVisible) {
+        [self.activitiyPopoverController dismissPopoverAnimated:YES];
+        return;
+    }
+    
     NSArray *activityItems;
     if (self.activityItems) {
         activityItems = [self.activityItems arrayByAddingObject:self.URL];


### PR DESCRIPTION
This commit adds the ability to dismiss the activity popover by tapping the
button that presented it. According to [the HIG](http://developer.apple.com/library/ios/#documentation/UserExperience/Conceptual/MobileHIG/UIElementGuidelines/UIElementGuidelines.html#//apple_ref/doc/uid/TP40006556-CH13-SW40): "A popover that provides
menu or inspector functionality should close when people tap anywhere outside
its bounds, **including the control that reveals the popover**." (emphasis
added.)

I didn't add an explicit check that the interface idiom is iPad because `popoverVisible` is `NO` (and the button cannot be tapped) when the activity view controller shown on iPhone.

Good work by the way. PBWebViewController looks great.
