### PR TITLE
iOS 7 implementation of `rightTriangleImage`

### DIFF
--- a/PBWebViewController/PBWebViewController.m
+++ b/PBWebViewController/PBWebViewController.m
@@ -98,8 +98,34 @@
 
 - (UIImage *)rightTriangleImage
 {
-    UIImage *image = [self leftTriangleImage];
-    return [UIImage imageWithCGImage:image.CGImage scale:image.scale orientation:UIImageOrientationDown];
+
+    static UIImage *rightTriangleImage;
+
+    static dispatch_once_t predicate;
+    dispatch_once(&predicate, ^{
+        UIImage *leftTriangleImage = [self leftTriangleImage];
+
+        CGSize size = leftTriangleImage.size;
+
+        UIGraphicsBeginImageContextWithOptions(size, NO, 0.0f);
+
+        CGContextRef context = UIGraphicsGetCurrentContext();
+
+        CGFloat x_mid = size.width / 2.0f;
+        CGFloat y_mid = size.height / 2.0f;
+
+        CGContextTranslateCTM(context, x_mid, y_mid);
+
+        CGContextRotateCTM(context, M_PI);
+        [leftTriangleImage drawAtPoint:CGPointMake((x_mid * -1), (y_mid * -1))];
+
+        rightTriangleImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+    });
+
+    return rightTriangleImage;
+
+
 }
 
 - (void)setupToolBarItems


### PR DESCRIPTION
Updated implementation of `- (UIImage *)rightTriangleImage` to
properly rotate image. Previous method does not work in iOS 7.

Before:
![bad](https://f.cloud.github.com/assets/15388/1318523/3b1fb5a6-32be-11e3-9e10-d755f3e9ea87.png)

After:
![good](https://f.cloud.github.com/assets/15388/1318524/407a1bcc-32be-11e3-9805-787e33af06d7.png)
