### PR TITLE
Implement ability to override activityItems

### DIFF
--- a/PBWebViewController/PBWebViewController.h
+++ b/PBWebViewController/PBWebViewController.h
@@ -22,11 +22,11 @@
  */
 @property (strong, nonatomic) NSURL *URL;
 
-/** The array of data objects on which to perform the activity. PBWebViewController always appends self.URL */
+/** 
+ * The array of data objects on which to perform the activity.
+ * PBWebViewController initialises it to  @[self.URL] if nothing is provided 
+ */
 @property (strong, nonatomic) NSArray *activityItems;
-
-/** The array of data objects on which to perform the activity. PBWebViewController will not append self.URL */
-@property (strong, nonatomic) NSArray *overrindingActivityItems;
 
 /** An array of UIActivity objects representing the custom services that your application supports. */
 @property (strong, nonatomic) NSArray *applicationActivities;

--- a/PBWebViewController/PBWebViewController.m
+++ b/PBWebViewController/PBWebViewController.m
@@ -212,20 +212,10 @@
         return;
     }
     
-    NSArray *activityItems;
-    if (self.overrindingActivityItems) {
-        
-        activityItems = self.overrindingActivityItems;
-    } else {
-        
-        if (self.activityItems) {
-            activityItems = [self.activityItems arrayByAddingObject:self.URL];
-        } else {
-            activityItems = @[self.URL];
-        }
-    }
+    if (self.activityItems == nil)
+        self.activityItems = @[self.URL];
     
-    UIActivityViewController *vc = [[UIActivityViewController alloc] initWithActivityItems:activityItems
+    UIActivityViewController *vc = [[UIActivityViewController alloc] initWithActivityItems:self.activityItems
                                                                      applicationActivities:self.applicationActivities];
     if (self.excludedActivityTypes) {
         vc.excludedActivityTypes = self.excludedActivityTypes;


### PR DESCRIPTION
Please consider retrofitting this in the main repository as sometimes as a user you want to control completely the activityItems presented to the activities.
Particularly true with complex `UIActivityItemProvider`s
