### PR TITLE
Use UIViewController's designated initializer instead of -[init]

### DIFF
--- a/PBWebViewController/PBWebViewController.m
+++ b/PBWebViewController/PBWebViewController.m
@@ -25,13 +25,27 @@
 
 @implementation PBWebViewController
 
-- (id)init
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-    self = [super init];
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
-        _showsNavigationToolbar = YES;
+        [self commonInit];
     }
     return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit
+{
+    _showsNavigationToolbar = YES;
 }
 
 - (void)load


### PR DESCRIPTION
There is no guarantee that `-init` will always be called when creating a new UIViewController. Hence setting the default value for `_showsNavigationToolbar` should be done in the designated initializer `-initWithNibName:bundle:`.

Also, when instantiating the view controller from a storyboard, nether `init` nor `initWithNibName:bundle` are called, we must implement `initWithCoder:`.
