### PR TITLE
Added forceReload property

### DIFF
--- a/PBWebViewController/PBWebViewController.h
+++ b/PBWebViewController/PBWebViewController.h
@@ -22,6 +22,8 @@
  */
 @property (strong, nonatomic) NSURL *URL;
 
+@property (nonatomic) BOOL forceReload;
+
 /** 
  * The array of data objects on which to perform the activity.
  * `@[self.URL]` is used if nothing is provided.

--- a/PBWebViewController/PBWebViewController.m
+++ b/PBWebViewController/PBWebViewController.m
@@ -50,7 +50,7 @@
 
 - (void)load
 {
-    NSURLRequest *request = [NSURLRequest requestWithURL:self.URL];
+    NSURLRequest *request = [NSURLRequest requestWithURL:self.URL cachePolicy:(self.forceReload ? NSURLRequestReloadIgnoringLocalCacheData : NSURLRequestReloadRevalidatingCacheData) timeoutInterval:4.0f];
     [self.webView loadRequest:request];
     
     if (self.navigationController.toolbarHidden) {


### PR DESCRIPTION
In some cases, with the current implementation, the PBWebViewController never refreshes the webView that's loaded. Added a forceReload property which, when set to YES, set the NSURLRequest's cachePolicy so it ignores the local cache and reloads the page.
