### PR TITLE
Made timeout the default 60 seconds

### DIFF
--- a/PBWebViewController/PBWebViewController.m
+++ b/PBWebViewController/PBWebViewController.m
@@ -50,7 +50,7 @@
 
 - (void)load
 {
-    NSURLRequest *request = [NSURLRequest requestWithURL:self.URL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:4.0];
+    NSURLRequest *request = [NSURLRequest requestWithURL:self.URL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60.0];
     [self.webView loadRequest:request];
     
     if (self.navigationController.toolbarHidden) {


### PR DESCRIPTION
The current timeout in PBWebViewController is 4 seconds. Many websites (such as this one recently linked on Reddit: http://antipope.org ) take a lot longer to start loading and thus fail on PBWebViewController.

An ideal future fix would allow developers to change this number. But for now I suggest that we keep the default NSURLRequest timeout of 60 seconds.