### PR TITLE
Use #import syntax instead of @import

### DIFF
--- a/PBSafariActivity/PBSafariActivity.h
+++ b/PBSafariActivity/PBSafariActivity.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Mikael Konutgan. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 /*
  * A `UIActivity` subclass to be used with a `UIActivityViewController` that opens a URL in Safari.

--- a/PBWebViewController/PBWebViewController.h
+++ b/PBWebViewController/PBWebViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Mikael Konutgan. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Using the `@import` syntax introduced in 732fa2cb00f16e9c7b519f34c134a377386cb415 and b6245d85bd07269cea29aba181302af3660ced05 prevents the pod to build if included in a project disabling modules.

See [this StackOverflow question for the same issue in the GoogleAnalytics pod](https://stackoverflow.com/questions/32314151/).

Using the `@import` syntax does not provides much, as [`#import` will still use modules as long as the project opted-in to use them](http://clang.llvm.org/docs/Modules.html#includes-as-imports):

> You don't actually need to use the `@import` keyword. If you opt-in to using modules, all `#import` and `#include` directives are mapped to use `@import` automatically.

https://stackoverflow.com/questions/18947516/import-vs-import-ios-7

Modules aren't supported for projects using Objective-C++, making your pod unusable for these projects.

Related issues in other projects:
https://github.com/jessesquires/JSQMessagesViewController/issues/541
https://github.com/stripe/stripe-ios/issues/220
https://github.com/andreamazz/UIView-Shake/pull/7
